### PR TITLE
Refactor endgame to allow user to play with same genre

### DIFF
--- a/src/app/endgame/endgame.component.html
+++ b/src/app/endgame/endgame.component.html
@@ -26,6 +26,6 @@
     <button class="button" routerLink="/gameplay">Play Again</button>
   </div>
   <div>
-    <button class="button" routerLink="/home">Home</button>
+    <button class="button" (click)="returnHome()" routerLink="/home">Home</button>
   </div>
 </div>

--- a/src/app/endgame/endgame.component.ts
+++ b/src/app/endgame/endgame.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute } from "@angular/router"
 import { FormControl, FormGroup } from "@angular/forms"
 import { Router } from "@angular/router"
 import { LeaderboardService } from "../../services/leaderboard.service"
+import { PlaylistService } from "src/services/playlist.service";
 
 @Component({
   selector: "app-endgame",
@@ -22,7 +23,8 @@ export class EndgameComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     private router: Router,
-    private leaderboardService: LeaderboardService
+    private leaderboardService: LeaderboardService,
+    private playlistService: PlaylistService
   ) {}
 
   ngOnInit(): void {
@@ -31,7 +33,6 @@ export class EndgameComponent implements OnInit {
       this.score = +params["score"]
       this.userForm.patchValue({ score: this.score })
     })
-    console.log(this.playerSubmitted)
   }
 
   onSubmit() {
@@ -48,5 +49,9 @@ export class EndgameComponent implements OnInit {
 
       alert("Your score was already submitted!")
     }
+  }
+
+  returnHome() {
+    this.playlistService.setPlaylist(null)
   }
 }

--- a/src/app/gameplay/gameplay.component.ts
+++ b/src/app/gameplay/gameplay.component.ts
@@ -53,7 +53,6 @@ export class GameplayComponent implements OnInit {
     if (this.sound) {
       this.sound.stop();
     }
-    this.playlistService.setPlaylist(null)
   }
 
   setMaxWrongAnswers() {


### PR DESCRIPTION
Removed clearing playlist from `ngOnDestroy()` after gameplay is finished, allowing user to play again using same genre.